### PR TITLE
API Use new serialize API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "opis/closure",
+    "name": "silverstripe/closure",
     "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
     "keywords": ["closure", "serialization", "function", "serializable", "serialize", "anonymous functions"],
     "homepage": "https://opis.io/closure",
@@ -15,7 +15,10 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0"
+        "php": "^8.1"
+    },
+    "replace": {
+        "opis/closure":"3.*"
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",
@@ -30,11 +33,6 @@
     "autoload-dev": {
         "psr-4": {
             "Opis\\Closure\\Test\\": "tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.6.x-dev"
         }
     },
     "config": {

--- a/src/ReflectionClosure.php
+++ b/src/ReflectionClosure.php
@@ -46,13 +46,13 @@ class ReflectionClosure extends ReflectionFunction
     /**
      * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         if ($this->isStaticClosure === null) {
             $this->isStaticClosure = strtolower(substr($this->getCode(), 0, 6)) === 'static';
         }
 
-        return $this->isStaticClosure;
+        return (bool) $this->isStaticClosure;
     }
 
     public function isShortClosure()

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -15,7 +15,7 @@ use ReflectionObject;
 /**
  * Provides a wrapper for serialization of closures
  */
-class SerializableClosure implements Serializable
+class SerializableClosure
 {
     /**
      * @var Closure Wrapped closure
@@ -109,12 +109,19 @@ class SerializableClosure implements Serializable
         return call_user_func_array($this->closure, func_get_args());
     }
 
+    public function __serialize(): array
+    {
+        return [
+            'serialized' => $this->serialize()
+        ];
+    }
+
     /**
      * Implementation of Serializable::serialize()
      *
      * @return  string  The serialized closure
      */
-    public function serialize()
+    private function serialize()
     {
         if ($this->scope === null) {
             $this->scope = new ClosureScope();
@@ -178,13 +185,18 @@ class SerializableClosure implements Serializable
         return $data;
     }
 
+    public function __unserialize(array $data): void
+    {
+        $this->unserialize($data['serialized']);
+    }
+
     /**
      * Implementation of Serializable::unserialize()
      *
      * @param   string $data Serialized data
      * @throws SecurityException
      */
-    public function unserialize($data)
+    private function unserialize($data)
     {
         ClosureStream::register();
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/11

Tag (don't release) 3.99.99 when merged - this is so that the composer "replace" works with existing installs that use ^3.6

Latest version on https://github.com/opis/closure is 3.6.3

I've used 3.* based on https://stackoverflow.com/a/18905069 - in that answer it says that using wildcard is bad, however in our case it does what we want it to do

If opis/closure 4 is ever released and the new serialize API is used there, then the silverstripe/closure fork should be deleted and silverstripe/doorman should be updated to use opis/closure again
